### PR TITLE
Changing Media denormalization to use publishable version. OCECDR-4335

### DIFF
--- a/Filters/CDR0000410709.xml
+++ b/Filters/CDR0000410709.xml
@@ -25,7 +25,7 @@
                                 select = "@cdr:ref"/>
   <xsl:variable                   name = "MediaInfo"
                                 select = "document(concat('cdr:',$MediaID,
-                                                           '/last'))"/>
+                                                           '/lastp'))"/>
   <xsl:element                    name = "MediaID">
    <xsl:attribute                 name = "cdr:ref">
     <xsl:value-of               select = "@cdr:ref"/>


### PR DESCRIPTION
A minor change to the MediaLink denormalization filter to pick up a publishable version instead of a regular version.