### PR TITLE
DrugReferenceLink in QC report

### DIFF
--- a/Filters/CDR0000486311.xml
+++ b/Filters/CDR0000486311.xml
@@ -68,14 +68,19 @@ Filter to create the DrugInformationSummary QC Report
   ==================================================================
   Display Report heading and subheading
   ================================================================== -->
-  <b>
-   <font size='4'>
+  <xsl:element                    name = "span">
+   <xsl:attribute                 name = "class">
+    <xsl:text>big</xsl:text>
+   </xsl:attribute>
+
     <center>
      <xsl:text>Drug Information Summary</xsl:text>
      <br/>
      <xsl:text>QC Report</xsl:text>
     </center>
-   </font>
+  </xsl:element>
+
+   <b>
    <font size='3'>
     <center>
      <xsl:value-of              select = "document(
@@ -90,13 +95,15 @@ Filter to create the DrugInformationSummary QC Report
   ====================================================================
   Display CDR ID
   ==================================================================== -->
-  <b>
-   <font size='4'>
-    <xsl:value-of               select = "concat('CDR',
+  <xsl:element                    name = "span">
+   <xsl:attribute                 name = "class">
+    <xsl:text>big</xsl:text>
+   </xsl:attribute>
+
+   <xsl:value-of                select = "concat('CDR',
                                            number(
                                            substring-after($docID, 'CDR')))"/>
-   </font>
-  </b>
+  </xsl:element>
   <p/>
 
   <!--
@@ -106,9 +113,13 @@ Filter to create the DrugInformationSummary QC Report
   <table        xsl:use-attribute-sets = "table">
    <tr>
     <td         xsl:use-attribute-sets = "cell1of2">
-     <b>
-      <font size="4">Title</font>
-     </b>
+     <xsl:element                 name = "span">
+      <xsl:attribute              name = "class">
+       <xsl:text>big</xsl:text>
+      </xsl:attribute>
+
+      <xsl:text>Title</xsl:text>
+     </xsl:element>
     </td>
     <td         xsl:use-attribute-sets = "cell2of2">
      <xsl:apply-templates       select = "Title"/>
@@ -121,9 +132,12 @@ Filter to create the DrugInformationSummary QC Report
   ===================================================================
   Display Drug Information Meta Data
   =================================================================== -->
-  <b>
-   <font size="4">Drug Info Meta Data</font>
-  </b>
+  <xsl:element                 name = "span">
+   <xsl:attribute              name = "class">
+    <xsl:text>big</xsl:text>
+   </xsl:attribute>
+   <xsl:text>Drug Info Meta Data</xsl:text>
+  </xsl:element>
   <xsl:apply-templates          select = "DrugInfoMetaData"/>
 
   <!--
@@ -133,9 +147,12 @@ Filter to create the DrugInformationSummary QC Report
   <table        xsl:use-attribute-sets = "table">
    <tr>
     <td         xsl:use-attribute-sets = "cell1of2">
-     <b>
-      <font size="4">Drug Info Summary</font>
-     </b>
+     <xsl:element                 name = "span">
+      <xsl:attribute              name = "class">
+       <xsl:text>big</xsl:text>
+      </xsl:attribute>
+      <xsl:text>Drug Info Summary</xsl:text>
+     </xsl:element>
     </td>
     <td         xsl:use-attribute-sets = "cell2of2">
      <xsl:apply-templates       select = "SummarySection"/>
@@ -290,6 +307,10 @@ Filter to create the DrugInformationSummary QC Report
  <!--
  ===================================================================
  Template to display the OtherNameType values
+
+ Note:  The proper display requires that the NLM DrugRefs are 
+        entered first and before the FDA DrugRefs.  If there are 
+        multiple NLM DrugRefs, those must be listed together.
  =================================================================== -->
  <xsl:template                   match = "DrugReference">
   <xsl:variable                   name = "fracID"
@@ -298,68 +319,151 @@ Filter to create the DrugInformationSummary QC Report
                                             MiscellaneousDocument/
                                             @cdr:ref, '#')"/>
 
-  <b>
-   <font size="4">
-    <xsl:text>Drug Reference - </xsl:text>
-    <xsl:value-of               select = "DrugReferenceType"/>
-   </font>
-  </b>
+  <!-- Store the number of NLM DrugRefs -->
+  <xsl:variable                   name = "nlmRefs"
+                                select = "count(//DrugReference[
+                                                    DrugReferenceType='NLM'
+                                                    ])"/>
+
+  <!-- 'NLM' may have multiple drugs but we only display one heading -->
+  <xsl:choose>
+   <xsl:when                      test = "DrugReferenceType = 'NLM'
+                                          and
+                                          position() = 1">
+    <xsl:element                  name = "span">
+     <xsl:attribute               name = "class">
+      <xsl:text>big</xsl:text>
+     </xsl:attribute>
+
+     <xsl:text>Drug Reference - </xsl:text>
+     <xsl:value-of              select = "DrugReferenceType"/>
+    </xsl:element>
+   </xsl:when>
+   <xsl:when                      test = "DrugReferenceType = 'NLM'
+                                          and
+                                          position() > 1">
+    <!-- Do nothing -->
+   </xsl:when>
+
+   <!-- Only display non-NLM headings here -->
+   <xsl:otherwise>
+    <xsl:element                  name = "span">
+     <xsl:attribute               name = "class">
+      <xsl:text>big</xsl:text>
+     </xsl:attribute>
+
+     <xsl:text>Drug Reference - </xsl:text>
+     <xsl:value-of              select = "DrugReferenceType"/>
+    </xsl:element>
+   </xsl:otherwise>
+  </xsl:choose>
+
   <table        xsl:use-attribute-sets = "table">
    <xsl:if                        test = "DrugReferencePostedDate">
     <tr>
-     <td         xsl:use-attribute-sets = "cell1of2">
+     <td        xsl:use-attribute-sets = "cell1of2">
       <b>Posted Date</b>
      </td>
-     <td         xsl:use-attribute-sets = "cell2of2">
-      <xsl:apply-templates       select = "DrugReferencePostedDate"/>
+     <td        xsl:use-attribute-sets = "cell2of2">
+      <xsl:apply-templates      select = "DrugReferencePostedDate"/>
      </td>
     </tr>
    </xsl:if>
-   <tr>
-    <td         xsl:use-attribute-sets = "cell1of2">
-     <b>Link</b>
-    </td>
-    <td         xsl:use-attribute-sets = "cell2of2">
-     <xsl:apply-templates       select = "DrugReferenceLink"/>
-     <br/>
-     <xsl:for-each              select = "DrugReferenceLink">
-      <xsl:call-template          name = "createWebLink"/>
-     </xsl:for-each>
-    </td>
-   </tr>
-   <tr>
-    <td         xsl:use-attribute-sets = "cell1of2">
-     <b>Description</b>
-    </td>
-    <td         xsl:use-attribute-sets = "cell2of2">
-     <xsl:apply-templates       select = "DrugReferenceDescription/
+
+   <!-- 'NLM' may have multiple drugs but we only display one heading -->
+   <xsl:choose>
+    <xsl:when                     test = "DrugReferenceType = 'NLM'
+                                          and
+                                          position() = 1">
+     <tr>
+      <td       xsl:use-attribute-sets = "cell1of2">
+       <b>Link</b>
+      </td>
+      <td       xsl:use-attribute-sets = "cell2of2">
+       <xsl:apply-templates     select = "DrugReferenceLink"/>
+       <br/>
+       <xsl:for-each            select = "DrugReferenceLink">
+        <xsl:call-template        name = "createWebLink"/>
+       </xsl:for-each>
+      </td>
+     </tr>
+    </xsl:when>
+    <xsl:when                     test = "DrugReferenceType = 'NLM'
+                                          and
+                                          position() > 1">
+     <tr>
+      <td       xsl:use-attribute-sets = "cell1of2">
+       <xsl:text> </xsl:text>
+      </td>
+      <td       xsl:use-attribute-sets = "cell2of2">
+       <xsl:apply-templates     select = "DrugReferenceLink"/>
+       <br/>
+       <xsl:for-each            select = "DrugReferenceLink">
+        <xsl:call-template        name = "createWebLink"/>
+       </xsl:for-each>
+      </td>
+     </tr>
+    </xsl:when>
+    <xsl:otherwise>
+     <tr>
+      <td       xsl:use-attribute-sets = "cell1of2">
+       <b>Link</b>
+      </td>
+      <td       xsl:use-attribute-sets = "cell2of2">
+       <xsl:apply-templates     select = "DrugReferenceLink"/>
+       <br/>
+       <xsl:for-each            select = "DrugReferenceLink">
+        <xsl:call-template        name = "createWebLink"/>
+       </xsl:for-each>
+      </td>
+     </tr>
+    </xsl:otherwise>
+   </xsl:choose>
+
+   <xsl:if                        test = "DrugReferenceType = 'NLM'
+                                         and
+                                         position() = $nlmRefs">
+    <tr>
+     <td        xsl:use-attribute-sets = "cell1of2">
+      <xsl:element                name = "span">
+       <xsl:attribute             name = "class">
+        <xsl:text>bold</xsl:text>
+       </xsl:attribute>
+
+       <xsl:text>Description </xsl:text>
+      </xsl:element>
+     </td>
+     <td        xsl:use-attribute-sets = "cell2of2">
+      <xsl:apply-templates      select = "DrugReferenceDescription/
                                           MiscellaneousDocument/
                                           MiscellaneousDocumentTitle"/>
-     <xsl:for-each              select = "DrugReferenceDescription/
+      <xsl:for-each             select = "DrugReferenceDescription/
                                           MiscellaneousDocument">
-      <xsl:call-template          name = "createCdrQcLink"/>
-     </xsl:for-each>
-     <br/>
-     <i><br/>
-      <div class="miscdoc">
-       <xsl:apply-templates     select = "DrugReferenceDescription//*[@cdr:id
+       <xsl:call-template         name = "createCdrQcLink"/>
+      </xsl:for-each>
+      <br/>
+      <i><br/>
+       <div class="miscdoc">
+        <xsl:apply-templates    select = "DrugReferenceDescription//*[@cdr:id
                                                                  = $fracID]"/>
-      </div>
-     </i>
-    </td>
-   </tr>
+       </div>
+      </i>
+     </td>
+    </tr>
+   </xsl:if>
+
    <xsl:if                        test = "Comment">
-   <tr>
-    <td         xsl:use-attribute-sets = "cell1of2">
-     <b>Comments</b>
-    </td>
-    <td         xsl:use-attribute-sets = "cell2of2">
-    <xsl:for-each               select = "Comment">
-     <xsl:apply-templates       select = "."/>
-     <br/>
-    </xsl:for-each>
-    </td>
-   </tr>
+    <tr>
+     <td        xsl:use-attribute-sets = "cell1of2">
+      <b>Comments</b>
+     </td>
+     <td        xsl:use-attribute-sets = "cell2of2">
+     <xsl:for-each              select = "Comment">
+      <xsl:apply-templates      select = "."/>
+      <br/>
+     </xsl:for-each>
+     </td>
+    </tr>
    </xsl:if>
   </table>
   <p/>
@@ -369,7 +473,7 @@ Filter to create the DrugInformationSummary QC Report
  ===================================================================
  Template to display the OtherNameType values
  =================================================================== -->
- <xsl:template                   name = "adminSection">
+ <xsl:template                    name = "adminSection">
   <hr width="35%"/>
   <table        xsl:use-attribute-sets = "table">
    <tr>


### PR DESCRIPTION
We copied a version of this filter to PROD a few days ago.  This version includes some resolved conflicts from that version (creating elements using <xsl:element/> instead of using HTML markup). 