### PR TITLE
Removing position() number from media title.

### DIFF
--- a/Filters/CDR0000339576.xml
+++ b/Filters/CDR0000339576.xml
@@ -2895,7 +2895,6 @@ OCECDR-3956: Allow CitationLinks in Image Captions
  ====================================================================== -->
  <xsl:template                   match = "MediaID | VideoID"
                                   mode = "gtc">
-  <xsl:value-of                 select = "position()"/>
   <xsl:choose>
    <!--
    If multiple images are displayed we need a linebreak before


### PR DESCRIPTION
I found a minor bug in the glossary QC report and pushed this through to PROD.  
The position number was displayed in front of the media title.