### PR TITLE
Suppress display of drug terms from section metadata. OCECDR-4630

### DIFF
--- a/Filters/CDR0000434822.xml
+++ b/Filters/CDR0000434822.xml
@@ -41,6 +41,7 @@ BZIssue::5065 - [Summaries] 2 More Patient Summary QC Report Display Options
  <xsl:template                   match = "DateLastModified |
                                           Diagnosis        |
                                           DocId            |
+                                          Drug             |
                                           MainTopics       |
                                           PatientVersionOf |
                                           PDQBoard         |


### PR DESCRIPTION
Same procedure as last time:
Minor change to suppress display of drug metadata from summary QC reports.