### PR TITLE
Filter change for Media QC Report

### DIFF
--- a/Filters/CDR0000433163.xml
+++ b/Filters/CDR0000433163.xml
@@ -370,7 +370,6 @@
       <xsl:attribute              name = "href">
        <xsl:value-of            select = "concat('/cgi-bin/cdr/',
                                                  'QcReport.py?Session=guest',
-                                                 '&amp;DocVersion=-1',
                                                  '&amp;DocId=',
                                                  $cdrId)"/>
 
@@ -1181,7 +1180,6 @@
     ======================================================= -->
     <xsl:value-of               select = "concat('/cgi-bin/cdr/QcReport.py',
                                                  '?Session=guest',
-                                                 '&amp;DocVersion=-1',
                                                  '&amp;ReportType=pat',
                                                  '&amp;DocId=',
                                                  $cdrId)"/>
@@ -1191,7 +1189,6 @@
     ======================================================= -->
     <xsl:value-of               select = "concat('/cgi-bin/cdr/QcReport.py',
                                                  '?Session=guest',
-                                                 '&amp;DocVersion=-1',
                                                  '&amp;ReportType=rs',
                                                  '&amp;DocId=',
                                                  $cdrId)"/>


### PR DESCRIPTION
Removing version=-1 for summary links since CWD is now specified as version=0 or no version. OCECDR-4715