### PR TITLE
Removing trailing newlines on alt attribute. OCECDR-4794

### DIFF
--- a/Filters/CDR0000271370.xml
+++ b/Filters/CDR0000271370.xml
@@ -269,13 +269,13 @@ OCECTS-116 - Add nct_id attribute to ProtocolRef element
       </xsl:when>
       <xsl:otherwise>
        <xsl:attribute             name = "alt">
-        <xsl:value-of           select = "MediaID/Media/
+        <xsl:value-of           select = "normalize-space(MediaID/Media/
                                           MediaContent/
                                           ContentDescriptions/
                                           ContentDescription
                                             [@language=$docLanguage
                                              and
-                                             @audience=$docAudience]"/>
+                                             @audience=$docAudience])"/>
        </xsl:attribute>
       </xsl:otherwise>
      </xsl:choose>
@@ -964,12 +964,12 @@ OCECTS-116 - Add nct_id attribute to ProtocolRef element
       </xsl:message>
      </xsl:if>
      <xsl:attribute               name = "alt">
-      <xsl:value-of             select = "../../
+      <xsl:value-of             select = "normalize-space(../../
                                           ContentDescriptions/
                                           ContentDescription
                                             [@language=$capLanguage
                                              and
-                                             @audience=$capAudience]"/>
+                                             @audience=$capAudience])"/>
      </xsl:attribute>
     </xsl:otherwise>
    </xsl:choose>


### PR DESCRIPTION
Filter change is on PROD to fix the broken glossary links.