### PR TITLE
(OCECDR-4824) HHS Syndication Hot-fix

### DIFF
--- a/Filters/CDR0000797103.xml
+++ b/Filters/CDR0000797103.xml
@@ -1430,7 +1430,7 @@
     <xsl:element name="a">
      <xsl:attribute name="href">
       <!-- Need to set hostname for image URL based on the tier we're on -->
-      <xsl:text>//nci-media@@MEDIA-TIER@@</xsl:text>
+      <xsl:text>https://nci-media@@MEDIA-TIER@@</xsl:text>
       <xsl:text>.cancer.gov</xsl:text>
       <xsl:text>/pdq/media/images/</xsl:text>
       <xsl:value-of             select = "number(
@@ -1470,7 +1470,7 @@
           <xsl:value-of         select = "@alt"/>
         </xsl:attribute>
         <xsl:attribute            name = "src">
-          <xsl:text>//nci-media@@MEDIA-TIER@@</xsl:text>
+          <xsl:text>https://nci-media@@MEDIA-TIER@@</xsl:text>
           <xsl:text>.cancer.gov</xsl:text>
           <xsl:text>/pdq/media/images/</xsl:text>
           <xsl:value-of         select = "number(


### PR DESCRIPTION
(OCECDR-4824) Adding https: to URL for nci-media server. Fixing HHS syndication link issue

This change has been copied to PROD.