### PR TITLE
Drop custom ZIP code validation (OCECDR-4781)

### DIFF
--- a/Schemas/CdrCommonBase.xml
+++ b/Schemas/CdrCommonBase.xml
@@ -36,18 +36,6 @@
      <assert>
       <test><![CDATA[
 @AddressType != "US" or
-                                        document(concat("cdrutil:/valid-zip/",
-                                                        PostalCode_ZIP)) != ""
-]]>
-      </test>
-      <message><![CDATA[
-U.S. address must have valid ZIP code
-]]>
-      </message>
-     </assert>
-     <assert>
-      <test><![CDATA[
-@AddressType != "US" or
                                         PoliticalSubUnit_State
 ]]>
       </test>


### PR DESCRIPTION
This should have been folded into Leibniz. I have restored the version of the schema which drops the obsolete custom validation rule on PROD.