### PR TITLE
Drug term loader

### DIFF
--- a/Filters/CDR0000801677.xml
+++ b/Filters/CDR0000801677.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" ?>
+<!-- Filter title: Drug Dictionary JSON -->
+<xsl:transform version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="cdr:name:JSON Common Templates"/>
+  <xsl:output method="text" indent="yes"/>
+
+  <!--
+
+    This stylesheet creates the Dictionary JSON structure containing Term details for
+    a single targeted Language, Audience and Dictionary.  Separate transformations are
+    required to generate the JSON structure for each permutation of the three parameters.
+
+    Correct function of these templates is VERY SENSITIVE TO EXTRA CARRIAGE RETURNS.
+    Be very careful when using an editor (e.g. Visual Studio) which automatically
+    reformats text to a "suggested" format.  Consider using a diff tool to check for
+    unexpected formatting changes before committing to source control.
+
+  -->
+
+  <!-- Default targets are English, Patient, drug dictionary -->
+  <xsl:param        name = "targetLanguage"
+                  select = "'English'"/>
+
+  <xsl:param        name = "targetAudience"
+                  select = "'Patient'" />
+
+  <xsl:param        name = "targetDictionary"
+                  select = "'Term'"/>
+
+  <!--
+    Set the audienceCode, languageCode, and dictionaryCode variables to use the same values
+    as the CDR. These variables provide a translation from the constants used by GateKeeper.
+  -->
+  <!-- General Audience code. MediaLink image uses different values. -->
+  <xsl:variable name="audienceCode">
+    <xsl:choose>
+      <xsl:when test="$targetAudience = 'Patient'">Patient</xsl:when>
+      <xsl:when test="$targetAudience = 'HealthProfessional'">Health professional</xsl:when>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:variable name="languageCode">
+    <xsl:choose>
+      <xsl:when test="$targetLanguage = 'English'">en</xsl:when>
+      <xsl:when test="$targetLanguage = 'Spanish'">es</xsl:when>
+    </xsl:choose>
+  </xsl:variable>
+
+  <xsl:variable name="dictionaryCode">
+    <xsl:choose>
+      <xsl:when test="$targetDictionary = 'Term'">Cancer.gov</xsl:when>
+      <xsl:when test="$targetDictionary = 'Genetic'">Genetics</xsl:when>
+    </xsl:choose>
+  </xsl:variable>
+
+
+  <!--
+    Match for the root (Term) element.  The entire JSON structure is created here.
+  -->
+<xsl:template match="/Term">
+{ <xsl:call-template name="RenderDocumentID" />
+  <xsl:call-template name="RenderTermName" />
+  <xsl:call-template name="RenderAliasList" />
+  <xsl:call-template name="RenderDateFirstPublished" />
+  <xsl:call-template name="RenderDateLastModified" />
+  <xsl:call-template name="RenderDefinition" />
+  <xsl:call-template name="RenderRelatedInformation" />
+}
+</xsl:template>
+
+  <xsl:template name="RenderDocumentID">
+  "id": "<xsl:call-template name="GetNumericID"><xsl:with-param name="cdrid" select="/Term/@id"/></xsl:call-template>",
+  </xsl:template>
+
+  <xsl:template name="RenderTermName">
+  "term": "<xsl:apply-templates select="//PreferredName"/>",
+  </xsl:template>
+
+  <xsl:template name="RenderAliasList">
+  "alias": <xsl:choose>
+      <xsl:when test="//OtherName">
+        <xsl:variable name="count" select="count(//OtherName)"/>
+        [<xsl:for-each select="//OtherName">
+          {
+            "name": "<xsl:apply-templates select="OtherTermName" />",
+            "type": "<xsl:value-of select="OtherNameType"/>"
+          }<xsl:if test="position() != $count">,</xsl:if>
+      </xsl:for-each>]
+      </xsl:when>
+      <xsl:otherwise>[] <!-- Empty list --></xsl:otherwise>
+    </xsl:choose>,
+  </xsl:template>
+
+  <xsl:template name="RenderDateFirstPublished">
+    <xsl:if test="//DateFirstPublished">"date_first_published": "<xsl:value-of select="//DateFirstPublished"/>", </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="RenderDateLastModified">
+    <xsl:if test="//DateLastModified">"date_last_modified": "<xsl:value-of select="//DateLastModified"/>", </xsl:if>
+  </xsl:template>
+
+  <!--
+    Renders the data structure containing the term's definition.
+
+    NOTE: Makes use of a locally defined "ExternalRef" template, rather than the one found in JSON-common-templates.
+  -->
+  <xsl:template name="RenderDefinition">
+  "definition": {
+    "html": "<xsl:apply-templates select="//Definition/DefinitionText" />",
+    "text": "<xsl:apply-templates select="//Definition/DefinitionText" mode="JSON" />"
+  },
+  </xsl:template>
+
+  <!--
+    Local implementation of ExternalRef (overrides JSON-common-templates) in order
+    to output the navigation-dark-red CSS class.
+  -->
+  <xsl:template match="ExternalRef"><!--
+    -->&lt;a class=\"navigation-dark-red\" href=\"<xsl:value-of select="@xref" />\"&gt;<xsl:apply-templates select="node()" />&lt;/a&gt;<!--
+--></xsl:template>
+
+
+
+  <!--
+    Renders the Related Information structure.
+
+    NOTE: This is the last item in the output data structure and therefore does not render a comma
+          at the end.
+  -->
+  <xsl:template name="RenderRelatedInformation">
+    "related": {
+    <xsl:call-template name="RenderRelatedDrugSummaries" />
+    }
+  </xsl:template>
+
+  <!--
+    Helper template to render the Drug Info Summary portion of the related information section.
+
+    NOTE: This data is not a native part of the Terminology document type.  This template will
+          likely need to be updated as OCEPROJECT-3605.
+  -->
+  <xsl:template name="RenderRelatedDrugSummaries">
+    "drug_summary": [
+    <xsl:variable name="count" select="count(//RelatedDrugInfoSummary)" />
+    <xsl:for-each select="//RelatedDrugInfoSummary">
+      {
+      "url": "<xsl:value-of select="."/>",
+      "text" : "<xsl:apply-templates select="//PreferredName" />"
+      }<xsl:if test="position() != $count">
+        ,
+      </xsl:if>
+    </xsl:for-each>
+    ]
+  </xsl:template>
+
+
+
+</xsl:transform>

--- a/Filters/CDR0000801678.xml
+++ b/Filters/CDR0000801678.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" ?>
+<!-- Filter title: JSON Common Templates -->
+<!--
+  Shared templates for the set of XSL files used for rendering JSON.
+
+  Correct function of these templates is VERY SENSITIVE TO EXTRA CARRIAGE RETURNS.
+  Be very careful when using an editor (e.g. Visual Studio) which automatically
+  reformats text to a "suggested" format.
+
+-->
+<xsl:transform version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:msxsl="urn:schemas-microsoft-com:xslt" exclude-result-prefixes="msxsl"
+>
+    <xsl:output method="text" indent="yes"/>
+
+
+  <!--
+    GetNumericID - Converts an id formatted CDR000012345 to a number with no leading zeros.
+
+    Args:
+      cdrid - A numeric ID with the first four characters being "CDR0".
+  -->
+  <xsl:template name="GetNumericID">
+    <xsl:param name="cdrid" />
+    <!--
+      translate - renders the letters to lowercase.
+      substring-after - remove the leading "cdr0"
+      number - convert to numeric, implictly removing leading zeros.
+    -->
+    <xsl:value-of select="number(substring-after(translate($cdrid,'CDR','cdr'), 'cdr0'))" />
+  </xsl:template>
+
+
+
+  <!--
+    Matches the ExternalRef, LOERef, ProtocolRef, GlossaryTermRef elements, outputting the common
+    xref attribute as a link.
+  -->
+  <xsl:template match="ExternalRef|LOERef|ProtocolRef|GlossaryTermRef"><!--
+    -->&lt;a href=\"<xsl:value-of select="@xref" />\"&gt;<xsl:apply-templates select="node()" />&lt;/a&gt;<!--
+--></xsl:template>
+
+
+  <!--
+    Matches the SummaryRef element.
+  -->
+  <xsl:template match="SummaryRef"><!--
+    -->&lt;a href=\"<xsl:value-of select="@url" />\"&gt;<xsl:apply-templates select="node()" />&lt;/a&gt;<!--
+--></xsl:template>
+
+
+  <!--
+     Match for all text nodes when processing with mode="JSON".
+     A call to xsl:apply-templates with mode="JSON" will cause the
+     text in a hierarchy of nodes to be output without element names.
+
+     NOTE: A template with match="node()" will take priority over this one.
+  -->
+  <xsl:template match="text()" mode="JSON">
+    <!-- Allow the regular processing for text nodes (below) to handle the element. -->
+    <xsl:apply-templates select="." />
+  </xsl:template>
+
+
+  <!--
+     Match for all Text nodes.  The text is sent through a series of substitutions
+     to escape special characters.
+
+     '\' is replaced with \\
+     Carriage return is replaced with \r.
+     Newline is replaced with \n.
+     Quotation mark is replaced with \".
+  -->
+  <xsl:template match="text()">
+    <!-- Preserve a leading space. -->
+    <xsl:variable name="leadingSpace">
+      <xsl:if test="starts-with(., ' ')"><xsl:text xml:space="preserve"> </xsl:text></xsl:if>
+    </xsl:variable>
+
+    <!-- Preserve a trailing space. -->
+    <xsl:variable name="trailingSpace">
+      <!-- There's no "ends-with() function, so we end using a slightly odd-looking expression
+           to check for trailing spaces. -->
+      <xsl:if test="string-length(.) > 0 and substring(., string-length(.)) = ' '"><xsl:text xml:space="preserve"> </xsl:text></xsl:if>
+    </xsl:variable>
+
+    <!-- Escape backslash in the current node ("string" param)
+         and cascade the change to all subsequent replacements. -->
+    <xsl:variable name="slashEscaped">
+      <xsl:call-template name="Replace">
+        <xsl:with-param name="string" select="." />
+        <xsl:with-param name="target" select="'\'" />
+        <xsl:with-param name="replace" select="'\\'" />
+      </xsl:call-template>
+    </xsl:variable>
+    <!-- Replace Carriage return -->
+    <xsl:variable name="returnEscaped">
+      <xsl:call-template name="Replace">
+        <xsl:with-param name="string" select="$slashEscaped" />
+        <xsl:with-param name="target" select="'&#xa;'" />
+        <xsl:with-param name="replace" select="'\r'" />
+      </xsl:call-template>
+    </xsl:variable>
+    <!-- Replace Newline -->
+    <xsl:variable name="newlineEscaped">
+      <xsl:call-template name="Replace">
+        <xsl:with-param name="string" select="$returnEscaped" />
+        <xsl:with-param name="target" select="'&#xd;'" />
+        <xsl:with-param name="replace" select="'\n'" />
+      </xsl:call-template>
+    </xsl:variable>
+    <!-- Replace quotation mark -->
+    <xsl:variable name="escaped">
+      <xsl:call-template name="Replace">
+        <xsl:with-param name="string" select="$newlineEscaped" />
+        <xsl:with-param name="target" select="'&quot;'" />
+        <xsl:with-param name="replace" select="'\&quot;'" />
+      </xsl:call-template>
+    </xsl:variable>
+    <!-- Output text with possible leading/trailing spaces. -->
+    <xsl:value-of select="$leadingSpace"/><xsl:value-of select="normalize-space($escaped)"/><xsl:value-of select="$trailingSpace"/>
+  </xsl:template>
+
+
+  <!--
+    Scans through the value contained in the $string parameter and replaces
+    all instances of $target with $replace.
+  -->
+  <xsl:template name="Replace">
+    <xsl:param name="string" />
+    <xsl:param name="target" />
+    <xsl:param name="replace" />
+
+    <xsl:choose>
+
+      <!-- string contains the target -->
+      <xsl:when test="contains($string, $target)">
+
+        <!-- Everything before the target-->
+        <xsl:variable name="pre" select="substring-before($string, $target)" />
+
+        <!-- Everything after the target goes back through the template. -->
+        <xsl:variable name="post">
+          <xsl:call-template name="Replace">
+            <xsl:with-param name="string" select="substring-after($string, $target)" />
+            <xsl:with-param name="target" select="$target" />
+            <xsl:with-param name="replace" select="$replace" />
+          </xsl:call-template>
+        </xsl:variable>
+
+        <!-- Rebuild the string with the replacement characters. -->
+        <xsl:value-of select="concat($pre, $replace, $post)"/>
+        <!--<xsl:value-of select="$pre"/>-->
+      </xsl:when>
+
+      <!--Just return the string-->
+      <xsl:otherwise>
+        <xsl:value-of select="$string"/>
+      </xsl:otherwise>
+    </xsl:choose>
+
+  </xsl:template>
+
+</xsl:transform>


### PR DESCRIPTION
These two XSL/T filters have been pull in from GateKeeper, which we will be turning off soon. The CDR will temporarily provide the functionality which GateKeeper has been providing, until the new drug dictionary API is in place. See Jira ticket OCECDR-4845.

The filters have been installed on all four tiers, including the production CDR server.