### PR TITLE
(OCECDR-4850) Remove internal-use attributes from FDAApproved element

### DIFF
--- a/Filters/CDR0000505580.xml
+++ b/Filters/CDR0000505580.xml
@@ -281,8 +281,7 @@ OCECDR-4122: Changes the order of information in DIS
    <xsl:if                        test = "not(/DrugInformationSummary
                                                 /DrugInfoMetaData
                                                 /DrugInfoType/@Combination)">
-    <xsl:apply-templates        select = "FDAApproved"
-                                  mode = "copy"/>
+    <xsl:apply-templates        select = "FDAApproved"/>
    </xsl:if>
 
    <xsl:element                   name = "TerminologyLink">
@@ -530,6 +529,17 @@ OCECDR-4122: Changes the order of information in DIS
 
    <xsl:apply-templates           mode = "copy"/>
   </xsl:element>
+ </xsl:template>
+
+
+ <!--
+ =====================================================================
+ Template to suppress attributes for FDAApproved
+ ===================================================================== -->
+ <xsl:template                   match = "FDAApproved">
+  <xsl:copy>
+   <xsl:value-of                select = "."/>
+  </xsl:copy>
  </xsl:template>
 
 


### PR DESCRIPTION
Minor filter change to strip out two internal-use elements from vendor output.