### PR TITLE
(OCECDR-4895) Remove ExtraDefinitionLinks tag from vendor output

### DIFF
--- a/Filters/CDR0000609947.xml
+++ b/Filters/CDR0000609947.xml
@@ -108,6 +108,19 @@ Filter to create Vendor Person XML documents
 
 
  <!--
+ Remove the element ExtraDefinitionLinks but keep the content
+ ============================================================ -->
+ <xsl:template                   match = "ExtraDefinitionLinks"
+                                  mode = "copy">
+  <xsl:apply-templates          select = "* | @* |
+                                          text() |
+                                          processing-instruction() |
+                                          comment()"
+                                  mode = "copy"/>
+ </xsl:template>
+
+
+ <!--
  Remove various elements from the licensee output
  ======================================================= -->
  <xsl:template                   match = "ArmsOrGroups         |


### PR DESCRIPTION
Filter change to remove the wrapper element (if it exists) has been copied to PROD.