### PR TITLE
(OCECDR-4940) Fixing missing proposed markup for citation links

### DIFF
--- a/Filters/CDR0000339576.xml
+++ b/Filters/CDR0000339576.xml
@@ -3661,29 +3661,40 @@ OCECDR-3956: Allow CitationLinks in Image Captions
       <xsl:when                   test = "@Source = 'advisory-board'">
        <xsl:choose>
         <xsl:when                 test = "@RevisionLevel = 'proposed'">
-         <span class="insertproposed_ad">
+         <xsl:element             name = "span">
+          <xsl:attribute          name = "class">
+           <xsl:text>insertproposed_ad</xsl:text>
+          </xsl:attribute>
           <xsl:text>[</xsl:text>
-         </span>
+         </xsl:element>
         </xsl:when>
         <xsl:otherwise>
-         <span class="insertapproved_ad">
+         <xsl:element             name = "span">
+          <xsl:attribute          name = "class">
+           <xsl:text>insertapproved_ad</xsl:text>
+          </xsl:attribute>
           <xsl:text>[</xsl:text>
-         </span>
-
+         </xsl:element>
         </xsl:otherwise>
        </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
        <xsl:choose>
         <xsl:when                 test = "@RevisionLevel = 'proposed'">
-         <span class="insertproposed">
+         <xsl:element             name = "span">
+          <xsl:attribute          name = "class">
+           <xsl:text>insertproposed</xsl:text>
+          </xsl:attribute>
           <xsl:text>[</xsl:text>
-         </span>
+         </xsl:element>
         </xsl:when>
         <xsl:otherwise>
-         <span class="insertapproved">
-         <xsl:text>[</xsl:text>
-         </span>
+         <xsl:element             name = "span">
+          <xsl:attribute          name = "class">
+           <xsl:text>insertapproved</xsl:text>
+          </xsl:attribute>
+          <xsl:text>[</xsl:text>
+         </xsl:element>
         </xsl:otherwise>
        </xsl:choose>
       </xsl:otherwise>
@@ -3699,14 +3710,20 @@ OCECDR-3956: Allow CitationLinks in Image Captions
         <xsl:otherwise>
          <xsl:choose>
           <xsl:when               test = "@RevisionLevel = 'proposed'">
-           <span class="deleteproposed_ad">
+           <xsl:element           name = "span">
+            <xsl:attribute        name = "class">
+             <xsl:text>deleteproposed_ad</xsl:text>
+            </xsl:attribute>
             <xsl:text>[</xsl:text>
-           </span>
+           </xsl:element>
           </xsl:when>
           <xsl:otherwise>
-           <span class="deleteapproved_ad">
+           <xsl:element           name = "span">
+            <xsl:attribute        name = "class">
+             <xsl:text>deleteapproved_ad</xsl:text>
+            </xsl:attribute>
             <xsl:text>[</xsl:text>
-           </span>
+           </xsl:element>
           </xsl:otherwise>
          </xsl:choose>
         </xsl:otherwise>
@@ -3720,14 +3737,20 @@ OCECDR-3956: Allow CitationLinks in Image Captions
         <xsl:otherwise>
          <xsl:choose>
           <xsl:when               test = "@RevisionLevel = 'proposed'">
-           <span class="deleteproposed">
+           <xsl:element           name = "span">
+            <xsl:attribute        name = "class">
+             <xsl:text>deleteproposed</xsl:text>
+            </xsl:attribute>
             <xsl:text>[</xsl:text>
-           </span>
+           </xsl:element>
           </xsl:when>
           <xsl:otherwise>
-           <span class="deleteapproved">
+           <xsl:element           name = "span">
+            <xsl:attribute        name = "class">
+             <xsl:text>deleteapproved</xsl:text>
+            </xsl:attribute>
             <xsl:text>[</xsl:text>
-           </span>
+           </xsl:element>
           </xsl:otherwise>
          </xsl:choose>
         </xsl:otherwise>
@@ -3745,102 +3768,124 @@ OCECDR-3956: Allow CitationLinks in Image Captions
   Displaying the citation ID with marked up
   ========================================= -->
   <xsl:choose>
-   <xsl:when                      test = "@InsertionOrDeletion
-                                            = 'Deletion'">
+   <xsl:when                      test = "@InsertionOrDeletion = 'Deletion'">
     <xsl:choose>
      <xsl:when                    test = "@Source = 'advisory-board'">
       <xsl:choose>
        <xsl:when                  test = "@RevisionLevel = 'proposed'">
-        <span class="deleteproposed_ad">
-         <xsl:call-template        name = "addCitationLink">
-          <xsl:with-param          name = "sectionID"
-                                 select = "$sectionID"/>
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>deleteproposed_ad</xsl:text>
+         </xsl:attribute>
+         <xsl:call-template       name = "addCitationLink">
+          <xsl:with-param         name = "sectionID"
+                                select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:when>
        <xsl:otherwise>
-        <span class="deleteapproved_ad">
-         <xsl:call-template        name = "addCitationLink">
-          <xsl:with-param          name = "sectionID"
-                                 select = "$sectionID"/>
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>deleteapproved_ad</xsl:text>
+         </xsl:attribute>
+         <xsl:call-template       name = "addCitationLink">
+          <xsl:with-param         name = "sectionID"
+                                select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:otherwise>
       </xsl:choose>
      </xsl:when>
      <xsl:otherwise>
       <xsl:choose>
        <xsl:when                  test = "@RevisionLevel = 'proposed'">
-        <span class="deleteproposed">
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>deleteproposed</xsl:text>
+         </xsl:attribute>
          <xsl:call-template       name = "addCitationLink">
           <xsl:with-param         name = "sectionID"
                                 select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:when>
        <xsl:otherwise>
-        <span class="deleteapproved">
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>deleteapproved</xsl:text>
+         </xsl:attribute>
          <xsl:call-template       name = "addCitationLink">
           <xsl:with-param         name = "sectionID"
                                 select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:otherwise>
       </xsl:choose>
      </xsl:otherwise>
     </xsl:choose>
    </xsl:when>
-   <xsl:when                      test = "@InsertionOrDeletion
-                                            = 'Insertion'">
+   <xsl:when                      test = "@InsertionOrDeletion = 'Insertion'">
     <xsl:choose>
      <xsl:when                    test = "@Source = 'advisory-board'">
       <xsl:choose>
        <xsl:when                  test = "@RevisionLevel = 'proposed'">
-        <span class="insertproposed_ad">
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>insertproposed_ad</xsl:text>
+         </xsl:attribute>
          <xsl:call-template       name = "addCitationLink">
           <xsl:with-param         name = "sectionID"
                                 select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:when>
        <xsl:otherwise>
-        <span class="insertapproved_ad">
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>insertapproved_ad</xsl:text>
+         </xsl:attribute>
          <xsl:call-template       name = "addCitationLink">
           <xsl:with-param         name = "sectionID"
                                 select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:otherwise>
       </xsl:choose>
      </xsl:when>
      <xsl:otherwise>
       <xsl:choose>
        <xsl:when                  test = "@RevisionLevel = 'proposed'">
-        <span class="insertproposed">
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>insertproposed</xsl:text>
+         </xsl:attribute>
          <xsl:call-template       name = "addCitationLink">
           <xsl:with-param         name = "sectionID"
 
                                 select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:when>
        <xsl:otherwise>
-        <span class="insertapproved">
+        <xsl:element              name = "span">
+         <xsl:attribute           name = "class">
+          <xsl:text>insertapproved</xsl:text>
+         </xsl:attribute>
          <xsl:call-template       name = "addCitationLink">
           <xsl:with-param         name = "sectionID"
                                 select = "$sectionID"/>
          </xsl:call-template>
-        </span>
+        </xsl:element>
        </xsl:otherwise>
       </xsl:choose>
      </xsl:otherwise>
     </xsl:choose>
    </xsl:when>
    <xsl:otherwise>
-         <xsl:call-template       name = "addCitationLink">
-          <xsl:with-param         name = "sectionID"
+    <xsl:call-template            name = "addCitationLink">
+     <xsl:with-param              name = "sectionID"
                                 select = "$sectionID"/>
-         </xsl:call-template>
+    </xsl:call-template>
    </xsl:otherwise>
   </xsl:choose>
 
@@ -3856,28 +3901,40 @@ OCECDR-3956: Allow CitationLinks in Image Captions
        <xsl:when                  test = "@Source = 'advisory-board'">
         <xsl:choose>
          <xsl:when                test = "@RevisionLevel = 'proposed'">
-          <span class="insertproposed_ad">
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertproposed_ad</xsl:text>
+           </xsl:attribute>
            <xsl:text>, </xsl:text>
-          </span>
+          </xsl:element>
          </xsl:when>
          <xsl:otherwise>
-          <span class="insertapproved_ad">
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertapproved_ad</xsl:text>
+           </xsl:attribute>
            <xsl:text>, </xsl:text>
-          </span>
+          </xsl:element>
          </xsl:otherwise>
         </xsl:choose>
        </xsl:when>
        <xsl:otherwise>
         <xsl:choose>
          <xsl:when                test = "@RevisionLevel = 'proposed'">
-          <span class="insertproposed">
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertproposed</xsl:text>
+           </xsl:attribute>
            <xsl:text>, </xsl:text>
-          </span>
+          </xsl:element>
          </xsl:when>
          <xsl:otherwise>
-          <span class="insertapproved">
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertapproved</xsl:text>
+           </xsl:attribute>
           <xsl:text>, </xsl:text>
-          </span>
+          </xsl:element>
          </xsl:otherwise>
         </xsl:choose>
        </xsl:otherwise>
@@ -3893,14 +3950,20 @@ OCECDR-3956: Allow CitationLinks in Image Captions
          <xsl:otherwise>
           <xsl:choose>
            <xsl:when              test = "@RevisionLevel = 'proposed'">
-            <span class="deleteproposed_ad">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteproposed_ad</xsl:text>
+             </xsl:attribute>
              <xsl:text>, </xsl:text>
-            </span>
+            </xsl:element>
            </xsl:when>
            <xsl:otherwise>
-            <span class="deleteapproved_ad">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteapproved_ad</xsl:text>
+             </xsl:attribute>
              <xsl:text>, </xsl:text>
-            </span>
+            </xsl:element>
            </xsl:otherwise>
           </xsl:choose>
          </xsl:otherwise>
@@ -3914,16 +3977,20 @@ OCECDR-3956: Allow CitationLinks in Image Captions
          <xsl:otherwise>
           <xsl:choose>
            <xsl:when              test = "@RevisionLevel = 'proposed'">
-            <span class="deleteproposed">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteproposed</xsl:text>
+             </xsl:attribute>
              <xsl:text>, </xsl:text>
-            </span>
+            </xsl:element>
            </xsl:when>
            <xsl:otherwise>
-            <span class="deleteapproved">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteapproved</xsl:text>
+             </xsl:attribute>
              <xsl:text>, </xsl:text>
-
-
-            </span>
+            </xsl:element>
            </xsl:otherwise>
           </xsl:choose>
          </xsl:otherwise>
@@ -3949,29 +4016,41 @@ OCECDR-3956: Allow CitationLinks in Image Captions
        <xsl:when                  test = "@Source = 'advisory-board'">
         <xsl:choose>
          <xsl:when                test = "@RevisionLevel = 'proposed'">
-          <span class="insertproposed_ad">
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertproposed_ad</xsl:text>
+           </xsl:attribute>
            <xsl:text>]</xsl:text>
-          </span>
+          </xsl:element>
          </xsl:when>
          <xsl:otherwise>
-          <span class="insertapproved_ad">
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertapproved_ad</xsl:text>
+           </xsl:attribute>
            <xsl:text>]</xsl:text>
-          </span>
+          </xsl:element>
          </xsl:otherwise>
         </xsl:choose>
        </xsl:when>
        <xsl:otherwise>
         <xsl:choose>
          <xsl:when                test = "@RevisionLevel = 'proposed'">
-          <span class="insertproposed">
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertproposed</xsl:text>
+           </xsl:attribute>
            <xsl:text>]</xsl:text>
 
-          </span>
+          </xsl:element>
          </xsl:when>
          <xsl:otherwise>
-          <span class="insertapproved">
-          <xsl:text>]</xsl:text>
-          </span>
+          <xsl:element            name = "span">
+           <xsl:attribute         name = "class">
+            <xsl:text>insertapproved</xsl:text>
+           </xsl:attribute>
+           <xsl:text>]</xsl:text>
+          </xsl:element>
          </xsl:otherwise>
         </xsl:choose>
        </xsl:otherwise>
@@ -3987,14 +4066,20 @@ OCECDR-3956: Allow CitationLinks in Image Captions
          <xsl:otherwise>
           <xsl:choose>
            <xsl:when              test = "@RevisionLevel = 'proposed'">
-            <span class="deleteproposed_ad">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteproposed_ad</xsl:text>
+             </xsl:attribute>
              <xsl:text>]</xsl:text>
-            </span>
+            </xsl:element>
            </xsl:when>
            <xsl:otherwise>
-            <span class="deleteapproved_ad">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteapproved_ad</xsl:text>
+             </xsl:attribute>
              <xsl:text>]</xsl:text>
-            </span>
+            </xsl:element>
            </xsl:otherwise>
           </xsl:choose>
          </xsl:otherwise>
@@ -4008,14 +4093,20 @@ OCECDR-3956: Allow CitationLinks in Image Captions
          <xsl:otherwise>
           <xsl:choose>
            <xsl:when              test = "@RevisionLevel = 'proposed'">
-            <span class="deleteproposed">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteproposed</xsl:text>
+             </xsl:attribute>
              <xsl:text>]</xsl:text>
-            </span>
+            </xsl:element>
            </xsl:when>
            <xsl:otherwise>
-            <span class="deleteapproved">
+            <xsl:element          name = "span">
+             <xsl:attribute       name = "class">
+              <xsl:text>deleteapproved</xsl:text>
+             </xsl:attribute>
              <xsl:text>]</xsl:text>
-            </span>
+            </xsl:element>
            </xsl:otherwise>
           </xsl:choose>
          </xsl:otherwise>
@@ -4060,49 +4151,66 @@ OCECDR-3956: Allow CitationLinks in Image Captions
  ====================================================================== -->
  <xsl:template                    name = "addCitationLink">
   <xsl:param                      name = "sectionID"/>
-         <xsl:element             name = "a">
-          <xsl:attribute          name = "href">
-           <xsl:text>#CL</xsl:text>
-           <xsl:value-of        select = "$sectionID"/>
-           <xsl:text>_</xsl:text>
-           <xsl:value-of        select = "@refidx"/>
-          </xsl:attribute>
-          <xsl:attribute          name = "title">
-           <xsl:choose>
-            <xsl:when             test = ". = ''">
-             <xsl:text>CITATION PLACEHOLDER</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-             <xsl:value-of      select = "."/>
-            </xsl:otherwise>
-           </xsl:choose>
-          </xsl:attribute>
-          <xsl:attribute          name = "class">
-           <xsl:text>citationLink</xsl:text>
-          </xsl:attribute>
-          <xsl:choose>
-            <xsl:when             test = "@iod = 'Insertion'">
-             <xsl:element         name = "span">
-              <xsl:attribute      name = "class">
-               <xsl:text>insertapproved</xsl:text>
-              </xsl:attribute>
-              <xsl:value-of          select = "@refidx"/>
-             </xsl:element>
-            </xsl:when>
-            <xsl:when             test = "@iod = 'Deletion'">
-             <xsl:element         name = "span">
-              <xsl:attribute      name = "class">
-               <xsl:text>deleteapproved</xsl:text>
-              </xsl:attribute>
-              <xsl:value-of     select = "@refidx"/>
-             </xsl:element>
-            </xsl:when>
-           <xsl:otherwise>
-            <xsl:value-of       select = "@refidx"/>
-           </xsl:otherwise>
-          </xsl:choose>
 
-         </xsl:element>
+  <xsl:element                    name = "a">
+   <xsl:attribute                 name = "href">
+    <xsl:text>#CL</xsl:text>
+    <xsl:value-of               select = "$sectionID"/>
+    <xsl:text>_</xsl:text>
+    <xsl:value-of               select = "@refidx"/>
+   </xsl:attribute>
+
+   <xsl:attribute                 name = "title">
+    <xsl:choose>
+     <xsl:when                    test = ". = ''">
+      <xsl:text>CITATION PLACEHOLDER</xsl:text>
+     </xsl:when>
+     <xsl:otherwise>
+      <xsl:value-of             select = "."/>
+     </xsl:otherwise>
+    </xsl:choose>
+   </xsl:attribute>
+
+   <xsl:attribute                 name = "class">
+    <xsl:text>citationLink</xsl:text>
+   </xsl:attribute>
+   <xsl:choose>
+    <xsl:when                     test = "@iod = 'Insertion'">
+     <xsl:element                 name = "span">
+      <xsl:attribute              name = "class">
+       <xsl:choose>
+        <xsl:when                 test = "@RevisionLevel = 'proposed'">
+         <xsl:text>insertproposed</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+         <xsl:text>insertapproved</xsl:text>
+        </xsl:otherwise>
+       </xsl:choose>
+      </xsl:attribute>
+      <xsl:value-of             select = "@refidx"/>
+     </xsl:element>
+    </xsl:when>
+    <xsl:when                     test = "@iod = 'Deletion'">
+     <xsl:element                 name = "span">
+      <xsl:attribute              name = "class">
+       <xsl:choose>
+        <xsl:when                 test = "@RevisionLevel = 'proposed'">
+         <xsl:text>deleteproposed</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+         <xsl:text>deleteapproved</xsl:text>
+        </xsl:otherwise>
+       </xsl:choose>
+      </xsl:attribute>
+      <xsl:value-of             select = "@refidx"/>
+     </xsl:element>
+    </xsl:when>
+    <xsl:otherwise>
+     <xsl:value-of              select = "@refidx"/>
+    </xsl:otherwise>
+   </xsl:choose>
+
+  </xsl:element>
  </xsl:template>
 
 


### PR DESCRIPTION
Sorry, there is a lot of noise replacing HTML span tags with the ELEMENT tag.  Only a few true changes at the bottom of the change list. 