### PR TITLE
Cdr5041 gloss alt name

### DIFF
--- a/Filters/CDR0000616048.xml
+++ b/Filters/CDR0000616048.xml
@@ -517,13 +517,14 @@ OCECDR-3966: Add URL Attribute for Gatekeeper Processing
                                             TermNameString"/>
    </xsl:when>
    <xsl:otherwise>
+    <!-- Excluding all names marked as NameType="alternate" -->
     <xsl:apply-templates        select = "/GlossaryTermName/
                                             GlossaryTermConcept/
                                             RelatedInformation/
                                             RelatedGlossaryTermNameLink
                                               [@cdr:ref = $relRef]/
                                             GlossaryTermName/
-                                            TranslatedName/
+                                            TranslatedName[not(@NameType)]/
                                             TermNameString"/>
    </xsl:otherwise>
   </xsl:choose>


### PR DESCRIPTION
Removing display of alternate name for Spanish "More Information" links.