### PR TITLE
(OCECDR-5180) Remove extra h (hour) character from timestamp

### DIFF
--- a/Filters/CDR0000000050.xml
+++ b/Filters/CDR0000000050.xml
@@ -962,7 +962,6 @@
   <xsl:value-of                 select = "$date"/>
   <xsl:text> </xsl:text>
   <xsl:value-of                 select = "$time"/>
-  <xsl:text> h</xsl:text>
  </xsl:template>
 
 

--- a/Filters/CDR0000257553.xml
+++ b/Filters/CDR0000257553.xml
@@ -533,6 +533,5 @@ Volker Englisch         2008-11-13
   <xsl:value-of                 select = "$date"/>
   <xsl:text> </xsl:text>
   <xsl:value-of                 select = "$time"/>
-  <xsl:text> h</xsl:text>
  </xsl:template>
 </xsl:transform>

--- a/Filters/CDR0000430928.xml
+++ b/Filters/CDR0000430928.xml
@@ -292,7 +292,6 @@ BZIssue::5166 - QC reports showing in table format
   <xsl:value-of                 select = "$date"/>
   <xsl:text> </xsl:text>
   <xsl:value-of                 select = "$time"/>
-  <xsl:text> h</xsl:text>
  </xsl:template>
 
 </xsl:transform>


### PR DESCRIPTION
Removal of extra " h" string has been copied to PROD.